### PR TITLE
feat: allow to merge external policy documents

### DIFF
--- a/kms-tfstates.tf
+++ b/kms-tfstates.tf
@@ -8,7 +8,7 @@ resource "aws_kms_key" "kms_tfstates" {
 }
 
 data "aws_iam_policy_document" "kms_tfstate_policy" {
-  source_policy_documents = var.statements
+  source_policy_documents = var.kms_policy_documents
 
   statement {
     sid = "Allow access for Key Administrators"

--- a/kms-tfstates.tf
+++ b/kms-tfstates.tf
@@ -8,6 +8,8 @@ resource "aws_kms_key" "kms_tfstates" {
 }
 
 data "aws_iam_policy_document" "kms_tfstate_policy" {
+  source_policy_documents = var.statements
+
   statement {
     sid = "Allow access for Key Administrators"
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,9 @@ variable "users" {
   type = list(string)
 }
 
-// JSON Statements list to merge to the iam policy document
 variable "statements" {
   type = list(string)
+  description = "JSON Statements list to merge to the iam policy document"
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "users" {
   type = list(string)
 }
 
+// JSON Statements list to merge to the iam policy document
+variable "statements" {
+  type = list(string)
+  default = []
+}
+
 // Tags to apply on s3_bucket
 variable "tags" {
   type = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,9 @@ variable "users" {
   type = list(string)
 }
 
-variable "statements" {
+variable "kms_policy_documents" {
   type = list(string)
-  description = "JSON Statements list to merge to the iam policy document"
+  description = "additional KMS policy documents (in JSON)"
   default = []
 }
 


### PR DESCRIPTION
With KMS, the way to add principal arns wildcards is to add a `ArnLike` condition with the list of PrincipalArn.

ie (with tf):

```hcl

  statement {
    sid = "Allow use of the key"

    principals {
      type        = "AWS"
      identifiers = ["*"]
    }

    actions = [
      "kms:Encrypt",
      "kms:Decrypt",
      "kms:ReEncrypt*",
      "kms:GenerateDataKey*",
      "kms:DescribeKey",
      "kms:List*",
    ]

    resources = ["*"]
    condition {
        test     = "ArnLike"
        variable = "aws:PrincipalArn"
        values   = ["arn:aws:iam::*:role/*"]
      }
  }
```

The module will allow to add JSON Statements list to merge to the iam policy document