### PR TITLE
feat: add deleteObject action to tech role

### DIFF
--- a/bucket-tfstates.tf
+++ b/bucket-tfstates.tf
@@ -68,6 +68,7 @@ data "aws_iam_policy_document" "bucket_tfstates_policy" {
       "s3:ListBucket",
       "s3:PutObject",
       "s3:GetObject",
+      "s3:DeleteObject",
     ]
 
     resources = [

--- a/variables.tf
+++ b/variables.tf
@@ -19,9 +19,9 @@ variable "users" {
 }
 
 variable "kms_policy_documents" {
-  type = list(string)
+  type        = list(string)
   description = "additional KMS policy documents (in JSON)"
-  default = []
+  default     = []
 }
 
 // Tags to apply on s3_bucket


### PR DESCRIPTION
# Context

Tech members can rm terraform ressource from all states today.
They should be able to delete the corresponding tf state file.